### PR TITLE
Add Interface name const to generated code

### DIFF
--- a/cmd/go-wayland-scanner/scanner.go
+++ b/cmd/go-wayland-scanner/scanner.go
@@ -216,6 +216,13 @@ func writeInterface(w io.Writer, v Interface) {
 	ifaceName := toCamel(v.Name)
 	ifaceNameLower := toLowerCamel(v.Name)
 
+	// Interface name
+	fmt.Fprintf(w, `// %sInterfaceName is the name of the interface as it appears in the [client.Registry].
+`, ifaceName)
+	fmt.Fprintf(w, "// It can be used to match the [client.RegistryGlobalEvent.Interface] in the\n")
+	fmt.Fprintf(w, "// [Registry.SetGlobalHandler] and can be used in [Registry.Bind] if this applies.\n")
+	fmt.Fprintf(w, "const %sInterfaceName = \"%s\"\n", ifaceName, v.Name)
+
 	// Interface struct
 	fmt.Fprintf(w, "// %s : %s\n", ifaceName, doc.Synopsis(v.Description.Summary))
 	fmt.Fprint(w, comment(v.Description.Text))


### PR DESCRIPTION
Exports the name of the interface. This avoids the user having to know the exact interface name and can help protect against typos.

This allows for the following code:

```go
func HandleRegistryGlobal(e client.RegistryGlobalEvent) {
	switch e.Interface {
	case idleNotify.IdleNotifierInterfaceName:
		m.notifier = idleNotify.NewIdleNotifier(m.context())
		err := m.registry.Bind(e.Name, e.Interface, e.Version, m.notifier)
		if err != nil {
			log.Fatalf("Unable to bind %s interface: %v", idleNotify.IdleNotifierInterfaceName, err)
		}
	case client.SeatInterfaceName:
		seat := client.NewSeat(m.context())
		err := m.registry.Bind(e.Name, e.Interface, e.Version, seat)
		if err != nil {
			log.Fatalf("unable to bind %s interface: %v", client.SeatInterfaceName, err)
		}
		m.seat = seat
	}
}
```

I did not include the generation changes in this PR because it would've required basing it on #8. As soon as that PR is merged and the URLs are updated, I can generate the code.

An example of the code it generates:
```go
// IdleNotifierInterfaceName is the name of the interface as it appears in the [client.Registry].
// It can be used to match the [client.RegistryGlobalEvent.Interface] in the
// [Registry.SetGlobalHandler] and can be used in [Registry.Bind] if this applies.
const IdleNotifierInterfaceName = "ext_idle_notifier_v1"
```

Any and all feedback welcome